### PR TITLE
feat: notes page with client-side markdown, syntax highlighting, and KaTeX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,5 @@ __marimo__/
 
 bin/
 pyvenv.cfg
+# Claude Code
+.claude/

--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ Flask web application for exploring IEEE-754 double-precision floating-point beh
 import math
 from decimal import ROUND_HALF_UP, Context
 
-from flask import Flask, jsonify, render_template, request
+from flask import Flask, jsonify, render_template, request, send_from_directory
 
 from fp import FP, Segment
 
@@ -115,6 +115,22 @@ def segment_process():
         "max_val": str(seg.max_val),
         "distance": str(seg.distance),
     })
+
+
+@app.route("/notes")
+def notes():
+    """Serve the floating-point notes page."""
+    return render_template("notes.html", nav_active="notes")
+
+
+@app.route("/notes/content")
+def notes_content():
+    """Serve the raw markdown notes file for client-side rendering."""
+    return send_from_directory(
+        "docs",
+        "floating-point-distribution-and-precision.md",
+        mimetype="text/plain",
+    )
 
 
 if __name__ == "__main__":

--- a/docs/floating-point-distribution-and-precision.md
+++ b/docs/floating-point-distribution-and-precision.md
@@ -6,7 +6,7 @@
 - [Informal precision](#precision) — spacing, hardware paths, and arbitrary-precision contrast
 - [IEEE representation](#floating-point-number-representation) — sign, exponent, and significand (normal numbers)
 - [Distribution](#distribution-of-floating-point-numbers-on-the-number-line) — segments, ULP, safe integers
-- [Decimal round-trips](#decimal-round-trips) — canonical decimals, digit limits, segment vs individual precision
+- [Decimal round-trips](#decimal-round-trips-and-precision) — canonical decimals, digit limits, segment vs individual precision
 
 ## Floating-point numbers vs real numbers
 

--- a/docs/superpowers/plans/2026-04-04-notes-page.md
+++ b/docs/superpowers/plans/2026-04-04-notes-page.md
@@ -1,0 +1,336 @@
+# Notes Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `/notes` route that renders `docs/floating-point-distribution-and-precision.md` as a readable page with syntax-highlighted code and KaTeX math.
+
+**Architecture:** Flask serves a shell template at `/notes` and the raw markdown at `/notes/content`. The browser fetches the markdown, parses it with marked.js, highlights code with highlight.js, and renders LaTeX with KaTeX auto-render — all client-side, no Python dependencies added.
+
+**Tech Stack:** Flask (existing), marked.js 12 (CDN), highlight.js 11.9 (CDN), KaTeX 0.16.10 + auto-render (CDN)
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `test_app.py` | Modify | Add route tests for `/notes` and `/notes/content` |
+| `app.py` | Modify | Add `send_from_directory` import; add `/notes` and `/notes/content` routes |
+| `templates/base.html` | Modify | Add "Notes" nav link |
+| `templates/notes.html` | Create | Shell template: CDN links, CSS, JS fetch+render pipeline |
+
+---
+
+### Task 1: Add route tests and implement Flask routes
+
+**Files:**
+- Modify: `test_app.py`
+- Modify: `app.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Add these two test methods to the `FloatingpointAppTestCase` class in `test_app.py`, after the existing `test_segment_empty` method:
+
+```python
+def test_notes_page(self) -> None:
+    response = self.client.get("/notes")
+    self.assertEqual(response.status_code, 200)
+    self.assertIn(b"notes-content", response.data)
+
+def test_notes_content(self) -> None:
+    response = self.client.get("/notes/content")
+    self.assertEqual(response.status_code, 200)
+    self.assertIn("text/plain", response.content_type)
+    self.assertIn(b"Floating-point numbers", response.data)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+python -m pytest test_app.py::FloatingpointAppTestCase::test_notes_page test_app.py::FloatingpointAppTestCase::test_notes_content -v
+```
+
+Expected: both tests FAIL with 404 (routes don't exist yet).
+
+- [ ] **Step 3: Add routes to app.py**
+
+Change the import line at the top of `app.py` from:
+
+```python
+from flask import Flask, jsonify, render_template, request
+```
+
+to:
+
+```python
+from flask import Flask, jsonify, render_template, request, send_from_directory
+```
+
+Then add these two routes after the `segment_process` function, before `if __name__ == "__main__":`:
+
+```python
+@app.route("/notes")
+def notes():
+    """Serve the floating-point notes page."""
+    return render_template("notes.html", nav_active="notes")
+
+
+@app.route("/notes/content")
+def notes_content():
+    """Serve the raw markdown notes file for client-side rendering."""
+    return send_from_directory(
+        "docs",
+        "floating-point-distribution-and-precision.md",
+        mimetype="text/plain",
+    )
+```
+
+- [ ] **Step 4: Create a minimal notes.html to unblock the tests**
+
+Create `templates/notes.html` with just enough to satisfy `test_notes_page` (the full template comes in Task 3):
+
+```html
+{% extends "base.html" %}
+{% block title %}Notes{% endblock %}
+{% block content %}
+<div class="notes-body">
+    <div id="notes-loading">Loading…</div>
+    <div id="notes-content"></div>
+</div>
+{% endblock %}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+python -m pytest test_app.py::FloatingpointAppTestCase::test_notes_page test_app.py::FloatingpointAppTestCase::test_notes_content -v
+```
+
+Expected: both PASS.
+
+- [ ] **Step 6: Run the full test suite to check for regressions**
+
+```bash
+python -m pytest test_app.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add test_app.py app.py templates/notes.html
+git commit -m "feat: add /notes and /notes/content routes"
+```
+
+---
+
+### Task 2: Add Notes link to the nav
+
+**Files:**
+- Modify: `templates/base.html`
+
+- [ ] **Step 1: Add the nav link**
+
+In `templates/base.html`, find the nav block (around line 163–168):
+
+```html
+        <a href="{{ url_for('segment_form') }}" {% if nav_active == 'segment' %}class="active"{% endif %}>Segment / ULP</a>
+    </nav>
+```
+
+Replace it with:
+
+```html
+        <a href="{{ url_for('segment_form') }}" {% if nav_active == 'segment' %}class="active"{% endif %}>Segment / ULP</a>
+        <a href="{{ url_for('notes') }}" {% if nav_active == 'notes' %}class="active"{% endif %}>Notes</a>
+    </nav>
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+```bash
+python -m pytest test_app.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add templates/base.html
+git commit -m "feat: add Notes link to nav"
+```
+
+---
+
+### Task 3: Build the full notes.html template
+
+**Files:**
+- Modify: `templates/notes.html`
+
+- [ ] **Step 1: Replace notes.html with the full template**
+
+Overwrite `templates/notes.html` with:
+
+```html
+{% extends "base.html" %}
+{% block title %}Notes{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css">
+<style>
+.notes-body {
+    max-width: 680px;
+    margin: 0 auto;
+    font-size: 17px;
+    line-height: 1.75;
+    color: #333;
+}
+.notes-body h1 {
+    text-align: left;
+}
+.notes-body h2 {
+    border-left: 4px solid #2e7d32;
+    padding-left: 12px;
+    color: #1b5e20;
+    margin-top: 2em;
+}
+.notes-body h3 {
+    border-left: 3px solid #4CAF50;
+    padding-left: 10px;
+    color: #2e7d32;
+    margin-top: 1.5em;
+}
+.notes-body h4 {
+    color: #333;
+    margin-top: 1.25em;
+}
+.notes-body pre {
+    background: #1e1e1e;
+    border-radius: 6px;
+    padding: 16px;
+    overflow-x: auto;
+    font-size: 14px;
+    line-height: 1.5;
+}
+.notes-body code:not(.hljs) {
+    background: #e9ecef;
+    padding: 2px 5px;
+    border-radius: 3px;
+    font-size: 15px;
+    font-family: 'Courier New', monospace;
+}
+.notes-body blockquote {
+    border-left: 4px solid #ddd;
+    margin: 0;
+    padding-left: 16px;
+    color: #666;
+}
+.notes-body table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 16px 0;
+    font-size: 15px;
+}
+.notes-body th,
+.notes-body td {
+    border: 1px solid #ddd;
+    padding: 8px 12px;
+    text-align: left;
+}
+.notes-body th {
+    background: #f5f5f5;
+    font-weight: bold;
+}
+.notes-body .katex-display {
+    overflow-x: auto;
+    padding: 8px 0;
+    margin: 1em 0;
+}
+#notes-loading {
+    color: #666;
+    text-align: center;
+    padding: 40px 0;
+}
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="notes-body">
+    <div id="notes-loading">Loading…</div>
+    <div id="notes-content"></div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js"></script>
+<script>
+  marked.use({
+    renderer: {
+      code({ text, lang }) {
+        const language = lang && hljs.getLanguage(lang) ? lang : 'plaintext';
+        const highlighted = hljs.highlight(text, { language }).value;
+        return `<pre><code class="hljs">${highlighted}</code></pre>`;
+      }
+    }
+  });
+
+  (async () => {
+    const loading = document.getElementById('notes-loading');
+    const content = document.getElementById('notes-content');
+    try {
+      const res = await fetch('/notes/content');
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const text = await res.text();
+      content.innerHTML = marked.parse(text);
+      renderMathInElement(content, {
+        delimiters: [
+          { left: '$$', right: '$$', display: true },
+          { left: '$',  right: '$',  display: false }
+        ],
+        throwOnError: false
+      });
+    } catch (err) {
+      content.innerHTML = `<p style="color:#721c24">Failed to load notes: ${err.message}</p>`;
+    } finally {
+      loading.style.display = 'none';
+    }
+  })();
+</script>
+{% endblock %}
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+```bash
+python -m pytest test_app.py -v
+```
+
+Expected: all tests PASS (the template change doesn't affect route tests).
+
+- [ ] **Step 3: Smoke-test in the browser**
+
+Start the app:
+
+```bash
+python app.py
+```
+
+Open `http://localhost:8080/notes` and verify:
+- The page loads with nav showing "Notes" as active
+- Content renders (headings, paragraphs visible within a few seconds)
+- Code blocks have syntax highlighting (dark background, colored tokens)
+- A math formula like the `N = (-1)^s \cdot ...` block renders as typeset math, not raw LaTeX
+- Anchor links in the outline at the top (e.g. "Intuition: floats vs reals") scroll to the correct section
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add templates/notes.html
+git commit -m "feat: render floating-point notes with markdown, syntax highlight, and KaTeX"
+```

--- a/docs/superpowers/specs/2026-04-04-notes-page-design.md
+++ b/docs/superpowers/specs/2026-04-04-notes-page-design.md
@@ -1,0 +1,54 @@
+# Notes page design
+
+**Date:** 2026-04-04
+
+## Goal
+
+Render `docs/floating-point-distribution-and-precision.md` as a proper `/notes` route in the Flask app, with client-side markdown rendering, syntax-highlighted code blocks, and LaTeX math via KaTeX.
+
+## Routes
+
+Two new routes added to `app.py`:
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/notes` | GET | Renders `notes.html` shell template with `nav_active="notes"` |
+| `/notes/content` | GET | Serves `docs/floating-point-distribution-and-precision.md` as `text/plain` via `send_from_directory` |
+
+`base.html` nav gets a "Notes" link alongside the existing Home / Exact value / Segment / ULP links.
+
+## Client-side rendering pipeline
+
+Three CDN libraries loaded in `notes.html`:
+
+- **marked.js** — parses markdown to HTML. A custom `code` renderer is wired in to call highlight.js at parse time.
+- **highlight.js** — syntax highlights fenced code blocks (Python, Java, JSON, text).
+- **KaTeX** + **KaTeX auto-render extension** — after HTML is injected into the DOM, `renderMathInElement()` scans for `$$...$$` (display math) and `$...$` (inline math) and renders them. Code elements are skipped automatically.
+
+Page load sequence:
+
+1. Fetch `/notes/content`
+2. `marked.parse(text)` → HTML string
+3. Inject into `<div id="notes-content">`
+4. `renderMathInElement(container, { delimiters: [$$, $] })`
+
+## Layout and typography
+
+- Outer body and nav remain at 900px (unchanged from `base.html`).
+- Inside `.container`, a `.notes-body` div is constrained to `max-width: 680px`, centered with `margin: 0 auto`.
+- Typography scoped to `.notes-body`:
+  - `font-size: 17px`, `line-height: 1.75`
+  - `h2` / `h3` with a left border in the site's green (`#2e7d32`)
+  - Code blocks: dark background (`#1e1e1e`), monospace, highlight.js theme
+  - KaTeX display math: centered, with vertical margin
+- The doc's outline at the top is an anchor-linked list; marked generates matching `id` attributes on headings by default, so in-page anchor links work without extra code.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `app.py` | Add `/notes` and `/notes/content` routes; import `send_from_directory` |
+| `templates/base.html` | Add "Notes" nav link |
+| `templates/notes.html` | New file — shell template with CDN scripts and render logic |
+
+No changes to `fp.py`, `fputil.py`, or the existing tool templates (`exact_decimal.html`, `segment.html`, `index.html`).

--- a/templates/base.html
+++ b/templates/base.html
@@ -165,6 +165,7 @@
         <a href="{{ url_for('index') }}" {% if nav_active == 'home' %}class="active"{% endif %}>Home</a>
         <a href="{{ url_for('exact_decimal_form') }}" {% if nav_active == 'exact_decimal' %}class="active"{% endif %}>Exact value</a>
         <a href="{{ url_for('segment_form') }}" {% if nav_active == 'segment' %}class="active"{% endif %}>Segment / ULP</a>
+        <a href="{{ url_for('notes') }}" {% if nav_active == 'notes' %}class="active"{% endif %}>Notes</a>
     </nav>
 
     <div class="container">

--- a/templates/base.html
+++ b/templates/base.html
@@ -156,8 +156,8 @@
             color: #2e7d32;
             font-weight: bold;
         }
-        {% block extra_css %}{% endblock %}
     </style>
+    {% block extra_css %}{% endblock %}
 </head>
 <body>
     <nav class="site-nav" aria-label="Main">

--- a/templates/exact_decimal.html
+++ b/templates/exact_decimal.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Exact value{% endblock %}
 {% block extra_css %}
+<style>
         .fp-schematic {
             margin: 16px 0 0 0;
             padding: 8px 0 0 0;
@@ -42,6 +43,7 @@
             margin-left: auto;
             margin-right: auto;
         }
+</style>
 {% endblock %}
 {% block content %}
 <h1>Exact value and d-digit decimals</h1>

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,6 +25,8 @@
             see the exact decimal for a float and which short decimal literals round to the same number.</li>
         <li><a href="{{ url_for('segment_form') }}">Segment / ULP</a> —
             see the exponent segment for a float and the exact spacing (ULP) between adjacent doubles in that band.</li>
+        <li><a href="{{ url_for('notes') }}">Floating-point notes</a> —
+            long-form companion covering representation, distribution, decimal round-trips, and precision in depth.</li>
     </ul>
 </div>
 {% endblock %}

--- a/templates/notes.html
+++ b/templates/notes.html
@@ -89,6 +89,7 @@
 {% endblock %}
 
 {% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
@@ -111,7 +112,7 @@
       const res = await fetch('/notes/content');
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const text = await res.text();
-      content.innerHTML = marked.parse(text);
+      content.innerHTML = DOMPurify.sanitize(marked.parse(text));
       renderMathInElement(content, {
         delimiters: [
           { left: '$$', right: '$$', display: true },
@@ -120,7 +121,10 @@
         throwOnError: false
       });
     } catch (err) {
-      content.innerHTML = `<p style="color:#721c24">Failed to load notes: ${err.message}</p>`;
+      const p = document.createElement('p');
+      p.style.color = '#721c24';
+      p.textContent = `Failed to load notes: ${err.message}`;
+      content.appendChild(p);
     } finally {
       loading.style.display = 'none';
     }

--- a/templates/notes.html
+++ b/templates/notes.html
@@ -111,6 +111,10 @@
         ],
         throwOnError: false
       });
+      if (location.hash) {
+        const target = document.querySelector(location.hash);
+        if (target) target.scrollIntoView();
+      }
     } catch (err) {
       const p = document.createElement('p');
       p.style.color = '#721c24';

--- a/templates/notes.html
+++ b/templates/notes.html
@@ -1,8 +1,129 @@
 {% extends "base.html" %}
 {% block title %}Notes{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css">
+<style>
+.notes-body {
+    max-width: 680px;
+    margin: 0 auto;
+    font-size: 17px;
+    line-height: 1.75;
+    color: #333;
+}
+.notes-body h1 {
+    text-align: left;
+}
+.notes-body h2 {
+    border-left: 4px solid #2e7d32;
+    padding-left: 12px;
+    color: #1b5e20;
+    margin-top: 2em;
+}
+.notes-body h3 {
+    border-left: 3px solid #4CAF50;
+    padding-left: 10px;
+    color: #2e7d32;
+    margin-top: 1.5em;
+}
+.notes-body h4 {
+    color: #333;
+    margin-top: 1.25em;
+}
+.notes-body pre {
+    background: #1e1e1e;
+    border-radius: 6px;
+    padding: 16px;
+    overflow-x: auto;
+    font-size: 14px;
+    line-height: 1.5;
+}
+.notes-body code:not(.hljs) {
+    background: #e9ecef;
+    padding: 2px 5px;
+    border-radius: 3px;
+    font-size: 15px;
+    font-family: 'Courier New', monospace;
+}
+.notes-body blockquote {
+    border-left: 4px solid #ddd;
+    margin: 0;
+    padding-left: 16px;
+    color: #666;
+}
+.notes-body table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 16px 0;
+    font-size: 15px;
+}
+.notes-body th,
+.notes-body td {
+    border: 1px solid #ddd;
+    padding: 8px 12px;
+    text-align: left;
+}
+.notes-body th {
+    background: #f5f5f5;
+    font-weight: bold;
+}
+.notes-body .katex-display {
+    overflow-x: auto;
+    padding: 8px 0;
+    margin: 1em 0;
+}
+#notes-loading {
+    color: #666;
+    text-align: center;
+    padding: 40px 0;
+}
+</style>
+{% endblock %}
+
 {% block content %}
 <div class="notes-body">
     <div id="notes-loading">Loading…</div>
     <div id="notes-content"></div>
 </div>
+{% endblock %}
+
+{% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js"></script>
+<script>
+  marked.use({
+    renderer: {
+      code({ text, lang }) {
+        const language = lang && hljs.getLanguage(lang) ? lang : 'plaintext';
+        const highlighted = hljs.highlight(text, { language }).value;
+        return `<pre><code class="hljs">${highlighted}</code></pre>`;
+      }
+    }
+  });
+
+  (async () => {
+    const loading = document.getElementById('notes-loading');
+    const content = document.getElementById('notes-content');
+    try {
+      const res = await fetch('/notes/content');
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const text = await res.text();
+      content.innerHTML = marked.parse(text);
+      renderMathInElement(content, {
+        delimiters: [
+          { left: '$$', right: '$$', display: true },
+          { left: '$',  right: '$',  display: false }
+        ],
+        throwOnError: false
+      });
+    } catch (err) {
+      content.innerHTML = `<p style="color:#721c24">Failed to load notes: ${err.message}</p>`;
+    } finally {
+      loading.style.display = 'none';
+    }
+  })();
+</script>
 {% endblock %}

--- a/templates/notes.html
+++ b/templates/notes.html
@@ -103,6 +103,10 @@
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const text = await res.text();
       content.innerHTML = DOMPurify.sanitize(marked.parse(text));
+      // marked v9+ removed headerIds; add them manually using the same slug algorithm
+      content.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach(h => {
+        h.id = h.textContent.toLowerCase().replace(/[^\w\s-]/g, '').trim().replace(/\s+/g, '-');
+      });
       content.querySelectorAll('pre code').forEach(block => hljs.highlightElement(block));
       renderMathInElement(content, {
         delimiters: [

--- a/templates/notes.html
+++ b/templates/notes.html
@@ -95,16 +95,6 @@
 <script src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js"></script>
 <script>
-  marked.use({
-    renderer: {
-      code({ text, lang }) {
-        const language = lang && hljs.getLanguage(lang) ? lang : 'plaintext';
-        const highlighted = hljs.highlight(text, { language }).value;
-        return `<pre><code class="hljs">${highlighted}</code></pre>`;
-      }
-    }
-  });
-
   (async () => {
     const loading = document.getElementById('notes-loading');
     const content = document.getElementById('notes-content');
@@ -113,6 +103,7 @@
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const text = await res.text();
       content.innerHTML = DOMPurify.sanitize(marked.parse(text));
+      content.querySelectorAll('pre code').forEach(block => hljs.highlightElement(block));
       renderMathInElement(content, {
         delimiters: [
           { left: '$$', right: '$$', display: true },

--- a/templates/notes.html
+++ b/templates/notes.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% block title %}Notes{% endblock %}
+{% block content %}
+<div class="notes-body">
+    <div id="notes-loading">Loading…</div>
+    <div id="notes-content"></div>
+</div>
+{% endblock %}

--- a/test_app.py
+++ b/test_app.py
@@ -90,6 +90,17 @@ class FloatingpointAppTestCase(unittest.TestCase):
         response = self.client.post("/segment", data={"decimal": ""})
         self.assertEqual(response.status_code, 400)
 
+    def test_notes_page(self) -> None:
+        response = self.client.get("/notes")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"notes-content", response.data)
+
+    def test_notes_content(self) -> None:
+        response = self.client.get("/notes/content")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("text/plain", response.content_type)
+        self.assertIn(b"Floating-point numbers", response.data)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Adds a `/notes` route rendering `docs/floating-point-distribution-and-precision.md` as a web page
- Client-side pipeline: marked.js → DOMPurify → highlight.js (per code block) → KaTeX auto-render
- 680px reading column with prose typography, green-accented headings
- Nav and homepage both link to the notes

## Technical notes

- Flask serves raw markdown at `/notes/content`; the shell template fetches and renders client-side
- `base.html` `{% block extra_css %}` moved outside `<style>` to allow child templates to inject `<link>` tags; `exact_decimal.html` updated accordingly
- Heading IDs generated manually after parse (marked v9+ removed `headerIds`)
- Hash anchor scroll handled after async render completes

## Test plan

- [ ] `python -m pytest test_app.py` — all 10 tests pass
- [ ] `/notes` loads with prose, syntax-highlighted code, and typeset math
- [ ] Outline anchor links and direct hash URLs scroll correctly
- [ ] `/exact-decimal` page CSS still intact
- [ ] Homepage lists the notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)