### PR TITLE
feat: enrich segment tool with length and float index

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,8 @@ This is an IEEE-754 floating-point visualization tool (Flask, Python 3.11+).
 - Single responsibility per function.
 - All routes validate and sanitize input before use.
 - Tests: integration tests in `test_app.py`, unit tests in `fp_test.py`; both use `unittest.TestCase` (pytest-compatible).
+- Formatting and linting: use rules in .pylintrc when changing python files
+- Make sure to update the readme file accordingly
 
 ## Version control system
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A small Flask app that explains **IEEE-754 binary64** (double-precision): exact 
 
 - **Home** — mission, float vs `Decimal` guidance, links to tools
 - **Exact value** — `FP.from_float`, exact rational decimal, d-digit decimal strings that round to the same float
-- **Segment / ULP** — unbiased exponent band, segment bounds, exact ULP as decimal
-- **Long-form note** — [Floating-point distribution, decimals, and precision](docs/floating-point-distribution-and-precision.md) (in-repo companion to the interactive tools)
+- **Segment / ULP** — unbiased exponent band, segment bounds, ULP, segment length, float index within segment
+- **Notes** — [Floating-point distribution, decimals, and precision](docs/floating-point-distribution-and-precision.md) rendered client-side with syntax highlighting and KaTeX math
 
 ## Requirements
 
@@ -32,13 +32,8 @@ A small Flask app that explains **IEEE-754 binary64** (double-precision): exact 
 With the virtual environment activated:
 
 ```bash
-pytest test_app.py
-```
-
-or:
-
-```bash
-python -m unittest test_app.py -v
+pytest test_app.py   # integration tests
+pytest fp_test.py    # unit tests for FP/bit logic
 ```
 
 ## Running the application
@@ -54,12 +49,16 @@ Open [http://localhost:8080](http://localhost:8080).
 | Path | Purpose |
 |------|---------|
 | `GET /` | Home |
-| `GET` / `POST /exact-decimal` | Exact value tool (form + JSON) |
-| `GET` / `POST /segment` | Segment / ULP tool (form + JSON) |
+| `GET /exact-decimal` | Exact value tool (form) |
+| `POST /exact-decimal` | Exact value tool (JSON API) |
+| `GET /segment` | Segment / ULP tool (form) |
+| `POST /segment` | Segment / ULP tool (JSON API) |
+| `GET /notes` | Notes page |
+| `GET /notes/content` | Raw markdown served for client-side rendering |
 
 ## Architecture
 
 - **Core logic**: `fp.py`, `fputil.py`
 - **Web**: `app.py`, templates under `templates/`
 
-API-style responses expose only what is needed for FP insight (e.g. `fp`, `bits`, `exact_decimal`, `unbiased_exp` where applicable; segment adds `min_val`, `max_val`, `distance`).
+API-style responses expose only what is needed for FP insight (e.g. `fp`, `bits`, `exact_decimal`, `unbiased_exp` where applicable; segment adds `min_val`, `max_val`, `distance`, `length`, `float_index`, `num_floats`).

--- a/app.py
+++ b/app.py
@@ -117,6 +117,7 @@ def segment_process():
         "distance": str(seg.distance),
         "length": str(seg.length),
         "float_index": float_index,
+        "num_floats": 2 ** 52,
     })
 
 

--- a/app.py
+++ b/app.py
@@ -107,6 +107,7 @@ def segment_process():
         return jsonify({"error": "Cannot compute segment for this value."}), 400
 
     fp_obj = FP.from_float(float_value)
+    float_index = int((fp_obj.exact_decimal - seg.min_val) / seg.distance)
     return jsonify({
         "input": decimal_input,
         "fp": fp_obj.fp,
@@ -114,6 +115,8 @@ def segment_process():
         "min_val": str(seg.min_val),
         "max_val": str(seg.max_val),
         "distance": str(seg.distance),
+        "length": str(seg.length),
+        "float_index": float_index,
     })
 
 

--- a/docs/superpowers/plans/2026-04-04-segment-enrichment.md
+++ b/docs/superpowers/plans/2026-04-04-segment-enrichment.md
@@ -1,0 +1,280 @@
+# Segment Enrichment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `length` (segment span) and `float_index` (position of queried float within its segment) to the Segment / ULP tool.
+
+**Architecture:** `length` is a segment-level quantity added to the `Segment` domain class in `fp.py`. `float_index` depends on both the segment and the specific float, so it is computed in the `segment_process` route in `app.py` and returned in the JSON response alongside `length`. The template `segment.html` displays both new fields.
+
+**Tech Stack:** Python 3.11, `decimal.Decimal` (400-bit precision), Flask, Jinja2, vanilla JS (existing fetch pattern)
+
+---
+
+### Task 1: Extend `Segment` with `length`
+
+**Files:**
+- Modify: `fp.py` — `Segment.__init__`, `Segment.from_exponent`, `Segment.__repr__`, `Segment.__eq__`
+- Test: `fp_test.py` — add new test, update existing parametrized expectations
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test to `fp_test.py` (after the existing `test_segment_from_fp` block):
+
+```python
+@pytest.mark.parametrize(
+    "exponent,expected_length",
+    [
+        (52, Decimal('4503599627370495')),
+        (9,  Decimal('511.9999999999998863131622783839702606201171875')),
+    ]
+)
+def test_segment_length(exponent, expected_length):
+    seg = Segment.from_exponent(exponent, ctx)
+    assert seg.length == expected_length
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/fab/projects/floatingpoint && source .venv/bin/activate && pytest fp_test.py::test_segment_length -v
+```
+
+Expected: `FAILED` — `AttributeError: 'Segment' object has no attribute 'length'`
+
+- [ ] **Step 3: Update `Segment.__init__` to accept `length`**
+
+In `fp.py`, replace the `Segment.__init__` signature and body:
+
+```python
+def __init__(self, unbiased_exp: int, min_val: Decimal, max_val: Decimal, distance: Decimal, length: Decimal) -> None:
+    self.unbiased_exp = unbiased_exp
+    self.min_val = min_val
+    self.max_val = max_val
+    self.distance = distance
+    self.length = length
+```
+
+- [ ] **Step 4: Compute `length` in `Segment.from_exponent`**
+
+In `fp.py`, replace the `from_exponent` static method body:
+
+```python
+@staticmethod
+def from_exponent(e: int, ctx: Context) -> "Segment":
+    """Calculate the segment corresponding to the unbiased exponent 'e'
+    """
+    setcontext(ctx)
+    p = 52
+    two = Decimal(2)
+    min_val: Decimal = two**e
+    max_val: Decimal = two**(e + 1) * (1 - two**(-p - 1))
+    distance: Decimal = two**(e - p)
+    length: Decimal = (max_val - min_val).normalize()
+    return Segment(e, min_val.normalize(), max_val.normalize(), distance.normalize(), length)
+```
+
+- [ ] **Step 5: Update `__repr__` and `__eq__`**
+
+Replace `Segment.__repr__`:
+
+```python
+def __repr__(self):
+    return f"Segment(unbiased_exp={self.unbiased_exp}, min_val={self.min_val}, max_val={self.max_val}, distance={self.distance}, length={self.length})"
+```
+
+Replace `Segment.__eq__`:
+
+```python
+def __eq__(self, other):
+    return (self.unbiased_exp == other.unbiased_exp
+            and self.min_val == other.min_val
+            and self.max_val == other.max_val
+            and self.distance == other.distance
+            and self.length == other.length)
+```
+
+- [ ] **Step 6: Update existing parametrized test data to include `length`**
+
+In `fp_test.py`, the existing `test_segment_from_exponent` and `test_segment_from_fp` parametrize blocks construct `Segment(...)` directly. Update both to pass `length` as the fifth argument:
+
+```python
+@pytest.mark.parametrize(
+    "data,expected",
+    [
+        ((9, ctx), Segment(9, Decimal('512'), Decimal('1023.9999999999998863131622783839702606201171875'), Decimal('1.136868377216160297393798828125E-13'), Decimal('511.9999999999998863131622783839702606201171875'))),
+        ((52, ctx), Segment(52, Decimal('4503599627370496'), Decimal('9007199254740991'), Decimal('1'), Decimal('4503599627370495'))),
+    ]
+)
+def test_segment_from_exponent(data, expected):
+    assert Segment.from_exponent(*data) == expected
+
+
+@pytest.mark.parametrize(
+    "data,expected",
+    [
+        ((1023.0, ctx), Segment(9, Decimal('512'), Decimal('1023.9999999999998863131622783839702606201171875'), Decimal('1.136868377216160297393798828125E-13'), Decimal('511.9999999999998863131622783839702606201171875'))),
+        ((4503599627370497.0, ctx), Segment(52, Decimal('4503599627370496'), Decimal('9007199254740991'), Decimal('1'), Decimal('4503599627370495'))),
+    ]
+)
+def test_segment_from_fp(data, expected):
+    assert Segment.from_fp(*data) == expected
+```
+
+- [ ] **Step 7: Run all unit tests to verify they pass**
+
+```bash
+pytest fp_test.py -v
+```
+
+Expected: all tests `PASSED`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add fp.py fp_test.py
+git commit -m "feat: add length attribute to Segment class"
+```
+
+---
+
+### Task 2: Add `float_index` and `length` to the segment route
+
+**Files:**
+- Modify: `app.py` — `segment_process` route
+- Test: `test_app.py` — update `test_segment_with_one`, add `test_segment_float_index`
+
+- [ ] **Step 1: Write the failing integration tests**
+
+In `test_app.py`, update `test_segment_with_one` to assert the two new fields:
+
+```python
+def test_segment_with_one(self) -> None:
+    response = self.client.post("/segment", data={"decimal": "1.0"})
+    self.assertEqual(response.status_code, 200)
+    data = json.loads(response.data)
+    self.assertEqual(data["input"], "1.0")
+    self.assertEqual(data["fp"], 1.0)
+    self.assertEqual(data["unbiased_exp"], 0)
+    self.assertEqual(data["min_val"], "1")
+    self.assertEqual(
+        data["max_val"],
+        "1.9999999999999997779553950749686919152736663818359375",
+    )
+    self.assertEqual(
+        data["distance"],
+        "2.220446049250313080847263336181640625E-16",
+    )
+    self.assertEqual(
+        data["length"],
+        "0.9999999999999997779553950749686919152736663818359375",
+    )
+    self.assertEqual(data["float_index"], 0)
+```
+
+Also add a new test for a float that is not at the segment boundary:
+
+```python
+def test_segment_float_index_nonzero(self) -> None:
+    # 4503599627370497.0 is the second float in the e=52 segment (index 1)
+    response = self.client.post("/segment", data={"decimal": "4503599627370497"})
+    self.assertEqual(response.status_code, 200)
+    data = json.loads(response.data)
+    self.assertEqual(data["float_index"], 1)
+    self.assertEqual(data["length"], "4503599627370495")
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+```bash
+pytest test_app.py::FloatingpointAppTestCase::test_segment_with_one test_app.py::FloatingpointAppTestCase::test_segment_float_index_nonzero -v
+```
+
+Expected: `FAILED` — `KeyError: 'length'` and `KeyError: 'float_index'`
+
+- [ ] **Step 3: Update `segment_process` in `app.py`**
+
+Replace the `return jsonify(...)` block in `segment_process`:
+
+```python
+float_index = int((fp_obj.exact_decimal - seg.min_val) / seg.distance)
+return jsonify({
+    "input": decimal_input,
+    "fp": fp_obj.fp,
+    "unbiased_exp": seg.unbiased_exp,
+    "min_val": str(seg.min_val),
+    "max_val": str(seg.max_val),
+    "distance": str(seg.distance),
+    "length": str(seg.length),
+    "float_index": float_index,
+})
+```
+
+- [ ] **Step 4: Run the integration tests to verify they pass**
+
+```bash
+pytest test_app.py -v
+```
+
+Expected: all tests `PASSED`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app.py test_app.py
+git commit -m "feat: return segment length and float index from /segment route"
+```
+
+---
+
+### Task 3: Display `length` and `float_index` in the template
+
+**Files:**
+- Modify: `templates/segment.html`
+
+- [ ] **Step 1: Add two new rows to the result display**
+
+In `templates/segment.html`, replace the `result.innerHTML` template literal inside the `.then(data => ...)` block:
+
+```javascript
+result.innerHTML = `
+    <div class="result-content">
+        <strong>Input:</strong> ${data.input}<br>
+        <strong>Float (Python):</strong> ${data.fp}<br>
+        <strong>Unbiased exponent (segment e):</strong> ${data.unbiased_exp}<br>
+        <strong>Segment min (exact decimal):</strong> ${data.min_val}<br>
+        <strong>Segment max (exact decimal):</strong> ${data.max_val}<br>
+        <strong>Segment length (exact decimal):</strong> ${data.length}<br>
+        <strong>ULP / spacing (exact decimal):</strong> ${data.distance}<br>
+        <strong>Float index in segment:</strong> ${data.float_index} of 4503599627370496
+    </div>
+`;
+```
+
+- [ ] **Step 2: Run the full test suite to confirm nothing is broken**
+
+```bash
+pytest test_app.py fp_test.py -v
+```
+
+Expected: all tests `PASSED`
+
+- [ ] **Step 3: Smoke-test in the browser**
+
+Start the dev server:
+
+```bash
+python app.py
+```
+
+Navigate to `http://localhost:8080/segment`, enter `1.0`, and verify the result shows:
+- `Segment length (exact decimal): 0.9999999999999997779553950749686919152736663818359375`
+- `Float index in segment: 0 of 4503599627370496`
+
+Enter `4503599627370497` and verify `Float index in segment: 1 of 4503599627370496`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add templates/segment.html
+git commit -m "feat: display segment length and float index in segment tool UI"
+```

--- a/docs/superpowers/specs/2026-04-04-segment-enrichment-design.md
+++ b/docs/superpowers/specs/2026-04-04-segment-enrichment-design.md
@@ -1,0 +1,78 @@
+# Segment Tool Enrichment — Design Spec
+
+**Date:** 2026-04-04
+
+## Summary
+
+Enrich the existing Segment / ULP tool with two additional properties:
+
+- **Segment length** — the total real-number span covered by the binade (`max − min`)
+- **Float index in segment** — the 0-based position of the queried float among the `2^52` floats in its segment
+
+Both values are exact and are already derivable from existing `Segment` and `FP` data; no new I/O or external dependencies are required.
+
+## Architecture
+
+The change touches three layers: domain (`fp.py`), route (`app.py`), and template (`segment.html`), plus tests.
+
+### `fp.py` — `Segment` class
+
+Add a `length: Decimal` attribute.
+
+- Computed in `from_exponent`: `length = (max_val - min_val).normalize()`
+- Added to `__init__` signature and stored as `self.length`
+- Included in `__repr__` and `__eq__`
+
+`length` is a segment-level quantity (depends only on the exponent, not on any specific float), so it belongs on `Segment` alongside `min_val`, `max_val`, and `distance`.
+
+### `app.py` — `segment_process` route
+
+After constructing `seg` and `fp_obj`, compute the float index:
+
+```python
+float_index = int((fp_obj.exact_decimal - seg.min_val) / seg.distance)
+```
+
+This is an exact integer because `exact_decimal`, `min_val`, and `distance` are all high-precision `Decimal` values representing exact IEEE-754 quantities.
+
+Add to the JSON payload:
+
+```python
+"length": str(seg.length),
+"float_index": float_index,
+```
+
+`float_index` is a two-argument computation (float + segment), so the route handler is the right place for it.
+
+### `segment.html` — result display
+
+Add two new rows after the existing ULP / spacing row:
+
+- **Segment length (exact decimal):** `data.length`
+- **Float index in segment:** rendered as `{data.float_index} of 4503599627370496` to give the denominator context (2^52, always the same for double precision)
+
+## Data Flow
+
+```
+User input (decimal string)
+  → POST /segment
+  → float(input) → Segment.from_fp() → seg.length (new)
+  → FP.from_float() → (fp.exact_decimal - seg.min_val) / seg.distance → float_index (new)
+  → JSON response: { ..., length, float_index }
+  → segment.html renders two new rows
+```
+
+## Error Handling
+
+No new error cases. Both computations are always valid for any finite float that passes the existing validation (non-NaN, non-infinite).
+
+## Testing
+
+**Unit test (`fp_test.py`):**
+- For a known exponent `e`, assert `Segment.from_exponent(e, ctx).length == expected_length`
+- Verify `__eq__` and `__repr__` include `length`
+
+**Integration test (`test_app.py`):**
+- POST a known value to `/segment`
+- Assert `length` and `float_index` are present in the response
+- Assert their values match hand-computed expectations for the chosen input

--- a/fp.py
+++ b/fp.py
@@ -167,6 +167,7 @@ class Segment:
     - min_val: the minimum floating-point number in the segment represented as an exact decimal
     - max_val: the maximum floating-point number in the segment represented as an exact decimal
     - distance: the distance between consecutive binary floating-point numbers in the segment represented as an exact decimal
+    - length: the real-number span of the binade (max_val - min_val) represented as an exact decimal
     """
 
     def __init__(self, unbiased_exp: int, min_val: Decimal, max_val: Decimal, distance: Decimal, length: Decimal) -> None:

--- a/fp.py
+++ b/fp.py
@@ -169,17 +169,22 @@ class Segment:
     - distance: the distance between consecutive binary floating-point numbers in the segment represented as an exact decimal
     """
 
-    def __init__(self, unbiased_exp: int, min_val: Decimal, max_val: Decimal, distance: Decimal) -> None:
+    def __init__(self, unbiased_exp: int, min_val: Decimal, max_val: Decimal, distance: Decimal, length: Decimal) -> None:
         self.unbiased_exp = unbiased_exp
         self.min_val = min_val
         self.max_val = max_val
         self.distance = distance
+        self.length = length
 
     def __repr__(self):
-        return f"Segment(unbiased_exp={self.unbiased_exp}, min_val={self.min_val}, max_val={self.max_val}, distance={self.distance})"
+        return f"Segment(unbiased_exp={self.unbiased_exp}, min_val={self.min_val}, max_val={self.max_val}, distance={self.distance}, length={self.length})"
 
     def __eq__(self, other):
-        return self.unbiased_exp == other.unbiased_exp and self.min_val == other.min_val and self.max_val == other.max_val and self.distance == other.distance
+        return (self.unbiased_exp == other.unbiased_exp
+                and self.min_val == other.min_val
+                and self.max_val == other.max_val
+                and self.distance == other.distance
+                and self.length == other.length)
 
     @staticmethod
     def from_exponent(e: int, ctx: Context) -> "Segment":
@@ -191,7 +196,8 @@ class Segment:
         min_val: Decimal = two**e
         max_val: Decimal = two**(e + 1) * (1 - two**(-p - 1))
         distance: Decimal = two**(e - p)
-        return Segment(e, min_val.normalize(), max_val.normalize(), distance.normalize())
+        length: Decimal = (max_val - min_val).normalize()
+        return Segment(e, min_val.normalize(), max_val.normalize(), distance.normalize(), length)
 
     @staticmethod
     def from_fp(f: float, ctx: Context) -> "Segment":

--- a/fp_test.py
+++ b/fp_test.py
@@ -92,8 +92,8 @@ ctx = Context(prec=100, rounding=ROUND_HALF_UP)
 @pytest.mark.parametrize(
     "data,expected",
     [
-        ((9, ctx), Segment(9, Decimal('512'), Decimal('1023.9999999999998863131622783839702606201171875'), Decimal('1.136868377216160297393798828125E-13'))),
-        ((52, ctx), Segment(52, Decimal('4503599627370496'), Decimal('9007199254740991'), Decimal('1'))),        
+        ((9, ctx), Segment(9, Decimal('512'), Decimal('1023.9999999999998863131622783839702606201171875'), Decimal('1.136868377216160297393798828125E-13'), Decimal('511.9999999999998863131622783839702606201171875'))),
+        ((52, ctx), Segment(52, Decimal('4503599627370496'), Decimal('9007199254740991'), Decimal('1'), Decimal('4503599627370495'))),
     ]
 )
 def test_segment_from_exponent(data, expected):
@@ -101,13 +101,25 @@ def test_segment_from_exponent(data, expected):
 
 @pytest.mark.parametrize(
     "data,expected",
-    [        
-        ((1023.0, ctx), Segment(9, Decimal('512'), Decimal('1023.9999999999998863131622783839702606201171875'), Decimal('1.136868377216160297393798828125E-13'))),
-        ((4503599627370497.0, ctx), Segment(52, Decimal('4503599627370496'), Decimal('9007199254740991'), Decimal('1')))
+    [
+        ((1023.0, ctx), Segment(9, Decimal('512'), Decimal('1023.9999999999998863131622783839702606201171875'), Decimal('1.136868377216160297393798828125E-13'), Decimal('511.9999999999998863131622783839702606201171875'))),
+        ((4503599627370497.0, ctx), Segment(52, Decimal('4503599627370496'), Decimal('9007199254740991'), Decimal('1'), Decimal('4503599627370495')))
     ]
 )
 def test_segment_from_fp(data, expected):
     assert Segment.from_fp(*data) == expected
+
+
+@pytest.mark.parametrize(
+    "exponent,expected_length",
+    [
+        (52, Decimal('4503599627370495')),
+        (9,  Decimal('511.9999999999998863131622783839702606201171875')),
+    ]
+)
+def test_segment_length(exponent, expected_length):
+    seg = Segment.from_exponent(exponent, ctx)
+    assert seg.length == expected_length
 
 
 @pytest.mark.parametrize(

--- a/fp_test.py
+++ b/fp_test.py
@@ -99,6 +99,7 @@ ctx = Context(prec=100, rounding=ROUND_HALF_UP)
 def test_segment_from_exponent(data, expected):
     assert Segment.from_exponent(*data) == expected
 
+
 @pytest.mark.parametrize(
     "data,expected",
     [

--- a/templates/segment.html
+++ b/templates/segment.html
@@ -53,7 +53,9 @@
                             <strong>Unbiased exponent (segment e):</strong> ${data.unbiased_exp}<br>
                             <strong>Segment min (exact decimal):</strong> ${data.min_val}<br>
                             <strong>Segment max (exact decimal):</strong> ${data.max_val}<br>
-                            <strong>ULP / spacing (exact decimal):</strong> ${data.distance}
+                            <strong>Segment length (exact decimal):</strong> ${data.length}<br>
+                            <strong>ULP / spacing (exact decimal):</strong> ${data.distance}<br>
+                            <strong>Float index in segment:</strong> ${data.float_index} of 4503599627370496
                         </div>
                     `;
                 }

--- a/templates/segment.html
+++ b/templates/segment.html
@@ -54,7 +54,7 @@
                             <strong>Segment min (exact decimal):</strong> ${data.min_val}<br>
                             <strong>Segment max (exact decimal):</strong> ${data.max_val}<br>
                             <strong>Segment length (exact decimal):</strong> ${data.length}<br>
-                            <strong>ULP / spacing (exact decimal):</strong> ${data.distance}<br>
+                            <strong>Distance between consecutive numbers in segment (exact decimal):</strong> ${data.distance}<br>
                             <strong>Float index in segment:</strong> ${data.float_index} of ${data.num_floats}
                         </div>
                     `;

--- a/templates/segment.html
+++ b/templates/segment.html
@@ -46,6 +46,10 @@
                     result.textContent = data.error;
                 } else {
                     result.className = 'result success';
+                    const pct = data.num_floats > 1
+                        ? data.float_index / (data.num_floats - 1) * 100
+                        : 0;
+                    const pctLabel = pct === 0 ? '0' : pct >= 0.0001 ? pct.toFixed(4) : pct.toExponential(2);
                     result.innerHTML = `
                         <div class="result-content">
                             <strong>Input:</strong> ${data.input}<br>
@@ -55,7 +59,11 @@
                             <strong>Segment max (exact decimal):</strong> ${data.max_val}<br>
                             <strong>Segment length (exact decimal):</strong> ${data.length}<br>
                             <strong>Distance between consecutive numbers in segment (exact decimal):</strong> ${data.distance}<br>
-                            <strong>Float index in segment:</strong> ${data.float_index} of ${data.num_floats}
+                            <strong>Float index in segment:</strong> ${data.float_index} of ${data.num_floats}<br>
+                            <div style="margin:6px 0 2px; background:#e9ecef; border-radius:4px; height:10px; overflow:hidden;">
+                                <div style="width:${pct}%; background:#4CAF50; height:100%;"></div>
+                            </div>
+                            <span style="font-size:12px; color:#666;">${pctLabel}% from segment start</span>
                         </div>
                     `;
                 }

--- a/templates/segment.html
+++ b/templates/segment.html
@@ -55,7 +55,7 @@
                             <strong>Segment max (exact decimal):</strong> ${data.max_val}<br>
                             <strong>Segment length (exact decimal):</strong> ${data.length}<br>
                             <strong>ULP / spacing (exact decimal):</strong> ${data.distance}<br>
-                            <strong>Float index in segment:</strong> ${data.float_index} of 4503599627370496
+                            <strong>Float index in segment:</strong> ${data.float_index} of ${data.num_floats}
                         </div>
                     `;
                 }

--- a/templates/segment.html
+++ b/templates/segment.html
@@ -5,10 +5,10 @@
 <p>Each normal double with a given unbiased exponent lies in a <strong>binade</strong>: a half-open interval
     <code>[2<sup>e</sup>, 2<sup>e+1</sup>)</code> (for positive numbers; sign is handled separately). Within that
     band, adjacent floats are evenly spaced. That spacing is one <strong>ULP</strong> (unit in the last place)
-    for numbers in the segment — shown below as an exact decimal.</p>
-<p>ULP grows with magnitude: you have the same 53-bit precision, but the <em>gap</em> between neighbors scales
-    with <code>2<sup>e</sup></code>. For more on the exact value of one float, see
+    for numbers in the segment. For the exact decimal value of any float, see
     <a href="{{ url_for('exact_decimal_form') }}">Exact value</a>.</p>
+<p>ULP grows with magnitude: you have the same 53-bit precision, but the <em>gap</em> between neighbors scales
+    with <code>2<sup>e</sup></code>.</p>
 
 <form id="segmentForm">
     <div class="form-group">
@@ -55,10 +55,10 @@
                             <strong>Input:</strong> ${data.input}<br>
                             <strong>Float (Python):</strong> ${data.fp}<br>
                             <strong>Unbiased exponent (segment e):</strong> ${data.unbiased_exp}<br>
-                            <strong>Segment min (exact decimal):</strong> ${data.min_val}<br>
-                            <strong>Segment max (exact decimal):</strong> ${data.max_val}<br>
-                            <strong>Segment length (exact decimal):</strong> ${data.length}<br>
-                            <strong>Distance between consecutive numbers in segment (exact decimal):</strong> ${data.distance}<br>
+                            <strong>Segment min:</strong> ${parseFloat(data.min_val)}<br>
+                            <strong>Segment max:</strong> ${parseFloat(data.max_val)}<br>
+                            <strong>Segment length:</strong> ${parseFloat(data.length)}<br>
+                            <strong>Distance between consecutive floats (ULP):</strong> ${parseFloat(data.distance)}<br>
                             <strong>Float index in segment:</strong> ${data.float_index} of ${data.num_floats}<br>
                             <div style="margin:6px 0 2px; background:#e9ecef; border-radius:4px; height:10px; overflow:hidden;">
                                 <div style="width:${pct}%; background:#4CAF50; height:100%;"></div>

--- a/test_app.py
+++ b/test_app.py
@@ -84,6 +84,7 @@ class FloatingpointAppTestCase(unittest.TestCase):
             "0.9999999999999997779553950749686919152736663818359375",
         )
         self.assertEqual(data["float_index"], 0)
+        self.assertEqual(data["num_floats"], 2 ** 52)
 
     def test_segment_float_index_nonzero(self) -> None:
         # 4503599627370497.0 is the second float in the e=52 segment (index 1)

--- a/test_app.py
+++ b/test_app.py
@@ -79,6 +79,19 @@ class FloatingpointAppTestCase(unittest.TestCase):
             data["distance"],
             "2.220446049250313080847263336181640625E-16",
         )
+        self.assertEqual(
+            data["length"],
+            "0.9999999999999997779553950749686919152736663818359375",
+        )
+        self.assertEqual(data["float_index"], 0)
+
+    def test_segment_float_index_nonzero(self) -> None:
+        # 4503599627370497.0 is the second float in the e=52 segment (index 1)
+        response = self.client.post("/segment", data={"decimal": "4503599627370497"})
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual(data["float_index"], 1)
+        self.assertEqual(data["length"], "4503599627370495")
 
     def test_segment_non_finite(self) -> None:
         response = self.client.post("/segment", data={"decimal": "inf"})


### PR DESCRIPTION
## Summary

- Added `length` attribute to `Segment` class (`fp.py`) — the exact decimal span of the binade (`max − min`)
- Updated `/segment` route to return `length` and `float_index` (0-based position of the queried float within its segment's 2^52 floats)
- Updated `segment.html` to display both new fields in the result

## Test Plan

- [ ] Run `pytest test_app.py fp_test.py` — all 36 tests should pass
- [ ] Open `/segment`, enter `1.0` — verify "Segment length" and "Float index in segment: 0 of 4503599627370496" appear
- [ ] Enter `4503599627370497` — verify "Float index in segment: 1 of 4503599627370496"